### PR TITLE
KA Gradescope link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,9 @@
         "eslint-config-next": "^14.1.0",
         "postcss": "^8",
         "tailwindcss": "^3.3.0"
+      },
+      "engines": {
+        "node": "18.19.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/src/app/assignments/speedgrader/page.jsx
+++ b/src/app/assignments/speedgrader/page.jsx
@@ -23,16 +23,13 @@ const GradescopeProject2ID = {
   "Sp24": 3866728
 }
 
-const nameID = {
-  "Oliver Hansen": 204884010,
-  "Van Henry": 206666694,
-  "April Tucker": 207287544,
-  "Ralph Hubbard": 208447816,
+const studentIDs = {
+  "Fa23": [204884010, 206666694, 207287544, 208447816],
+  "Sp24": []
 };
 
 export default function Page() {
-  const [personName, setPersonName] = React.useState("");
-  const [personID, setPersonID] = React.useState("");
+  const [studentID, setStudentID] = React.useState("");
   const [points, setPoints] = React.useState("");
   const [maxPoints, setMaxPoints] = React.useState(30);
   const [feedback, setFeedback] = React.useState("Comments");
@@ -103,7 +100,7 @@ export default function Page() {
               marginLeft: '0.5em'
             }}
           >
-            To get started, select a student from the Name dropdown.
+            To get started, select a student from the Gradescope Student ID dropdown.
           </Typography>
         );
       }
@@ -262,11 +259,8 @@ export default function Page() {
           }}
         >
           <MultipleSelect
-            personName={personName}
-            setPersonName={setPersonName}
-            personID={personID}
-            setPersonID={setPersonID}
-            nameID={nameID}
+            setStudentID={setStudentID}
+            studentIDs={studentIDs}
             setFeedback={setFeedback}
             setEditedFeedback={setEditedFeedback}
             setCode={setCode}

--- a/src/app/assignments/speedgrader/page.jsx
+++ b/src/app/assignments/speedgrader/page.jsx
@@ -29,7 +29,7 @@ const studentIDs = {
 };
 
 export default function Page() {
-  const [studentID, setStudentID] = React.useState("");
+  const [studentID, setStudentID] = React.useState(-1);
   const [points, setPoints] = React.useState("");
   const [maxPoints, setMaxPoints] = React.useState(30);
   const [feedback, setFeedback] = React.useState("Comments");
@@ -89,6 +89,15 @@ export default function Page() {
     return codeFileContents[codeFileIndex];
   };
 
+  const gotoGradescope = () => {
+    const gradescopeLink = 'https://www.gradescope.com/courses/' + GradescopeCourseID["Fa23"]
+      + '/assignments/' + GradescopeProject2ID["Fa23"]
+      + '/submissions/' + studentID
+      + '?view=files';
+
+    window.open(gradescopeLink, '_blank');
+  }
+
   const renderPage = () => {
     if (page === 0) {
       if (code === "") {
@@ -125,7 +134,7 @@ export default function Page() {
               marginLeft: '0.5em'
             }}
           >
-            To get started, select a student from the Name dropdown.
+            To get started, select a student from the Gradescope Student ID dropdown.
           </Typography>
         );
       }
@@ -214,28 +223,30 @@ export default function Page() {
           >
             {renderPage()}
           </Paper>
-          <Tabs
-            value={page}
-            onChange={handlePageChange}
-            variant="outlined"
-            sx={{
-              paddingTop: "20px",
-              width: "50%"
-            }}
-          >
-            <Tab
-              label="Code"
+          {studentID != -1 && (
+            <Tabs
+              value={page}
+              onChange={handlePageChange}
+              variant="outlined"
               sx={{
-                flexGrow: 1
+                paddingTop: "20px",
+                width: "50%"
               }}
-            />
-            <Tab
-              label="Report"
-              sx={{
-                flexGrow: 1
-              }}
-            />
-          </Tabs>
+            >
+              <Tab
+                label="Code"
+                sx={{
+                  flexGrow: 1
+                }}
+              />
+              <Tab
+                label="Report"
+                sx={{
+                  flexGrow: 1
+                }}
+              />
+            </Tabs>
+          )}
         </Box>
       </Box>
       <Box
@@ -268,15 +279,42 @@ export default function Page() {
             setPoints={setPoints}
             setSelectedCodeFile={setSelectedCodeFile}
           />
-          <TextField
-            value={points}
-            onChange={handlePointsChange}
-            label="Points"
-            variant="outlined"
-            helperText={"out of "+ maxPoints}
-            FormHelperTextProps={{ sx: {fontSize: '1rem'} }}
-            sx={{ width: "100px" }}
-          />
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "row",
+              justifyContent: "flex-start",
+              alignItems: "center",
+              gap: "50px"
+            }}
+          >
+            <TextField
+              value={points}
+              onChange={handlePointsChange}
+              label="Points"
+              variant="outlined"
+              helperText={"out of "+ maxPoints}
+              FormHelperTextProps={{ sx: {fontSize: '1rem'} }}
+              sx={{ width: "100px" }}
+            />
+            {studentID != -1 && (
+              <Button
+                onClick={gotoGradescope}
+                sx={{
+                  fontSize: '1rem',
+                  padding: '0.25em 0.5em',
+                  color: 'white',
+                  backgroundColor: '#fbac13',
+                  whiteSpace: 'nowrap',
+                  fontWeight: 'bold',
+                  marginBottom: '2em',
+                  '&:hover': { backgroundColor: '#fbac13'}
+                }}
+              >
+                Gradescope Submission
+              </Button>
+            )}
+          </Box>
           <TextField
             variant="outlined"
             label="Comments"
@@ -286,19 +324,21 @@ export default function Page() {
             onChange={handleFeedbackChange}
             fullWidth
           />
-          <Button
-            sx={{
-              fontSize: '1.5rem',
-              padding: '0.25em 0.5em',
-              color: 'white',
-              backgroundColor: '#1c65ee',
-              whiteSpace: 'nowrap',
-              fontWeight: 'bold',
-              '&:hover': { backgroundColor: '#1c65ee'}
-            }}
-          >
-            Update Submission
-          </Button>
+          {studentID != -1 && (
+            <Button
+              sx={{
+                fontSize: '1.5rem',
+                padding: '0.25em 0.5em',
+                color: 'white',
+                backgroundColor: '#1c65ee',
+                whiteSpace: 'nowrap',
+                fontWeight: 'bold',
+                '&:hover': { backgroundColor: '#1c65ee'}
+              }}
+            >
+              Update Submission
+            </Button>
+          )}
         </Box>
       </Box>
     </Box>

--- a/src/app/assignments/speedgrader/page.jsx
+++ b/src/app/assignments/speedgrader/page.jsx
@@ -9,6 +9,7 @@ import Tabs from '@mui/material/Tabs';
 import Tab from '@mui/material/Tab';
 import Select from '@mui/material/Select';
 import MenuItem from '@mui/material/MenuItem';
+import ExitToAppIcon from "@mui/icons-material/ExitToApp";
 import { Prism as SyntaxHighlighter} from "react-syntax-highlighter";
 import { oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import MultipleSelect from "../../ui/studentSelector";
@@ -269,52 +270,52 @@ export default function Page() {
             gap: "25px",
           }}
         >
-          <MultipleSelect
-            setStudentID={setStudentID}
-            studentIDs={studentIDs}
-            setFeedback={setFeedback}
-            setEditedFeedback={setEditedFeedback}
-            setCode={setCode}
-            setReport={setReport}
-            setPoints={setPoints}
-            setSelectedCodeFile={setSelectedCodeFile}
-          />
           <Box
             sx={{
               display: "flex",
               flexDirection: "row",
               justifyContent: "flex-start",
               alignItems: "center",
-              gap: "50px"
+              gap: "20px"
             }}
           >
-            <TextField
-              value={points}
-              onChange={handlePointsChange}
-              label="Points"
-              variant="outlined"
-              helperText={"out of "+ maxPoints}
-              FormHelperTextProps={{ sx: {fontSize: '1rem'} }}
-              sx={{ width: "100px" }}
+            <MultipleSelect
+              setStudentID={setStudentID}
+              studentIDs={studentIDs}
+              setFeedback={setFeedback}
+              setEditedFeedback={setEditedFeedback}
+              setCode={setCode}
+              setReport={setReport}
+              setPoints={setPoints}
+              setSelectedCodeFile={setSelectedCodeFile}
             />
             {studentID != -1 && (
               <Button
                 onClick={gotoGradescope}
                 sx={{
-                  fontSize: '1rem',
+                  fontSize: '0.85rem',
                   padding: '0.25em 0.5em',
                   color: 'white',
                   backgroundColor: '#fbac13',
                   whiteSpace: 'nowrap',
                   fontWeight: 'bold',
-                  marginBottom: '2em',
-                  '&:hover': { backgroundColor: '#fbac13'}
+                  '&:hover': { backgroundColor: '#fbac13'},
+                  gap: '5px'
                 }}
               >
-                Gradescope Submission
+                Gradescope <ExitToAppIcon/>
               </Button>
             )}
           </Box>
+          <TextField
+            value={points}
+            onChange={handlePointsChange}
+            label="Points"
+            variant="outlined"
+            helperText={"out of "+ maxPoints}
+            FormHelperTextProps={{ sx: {fontSize: '1rem'} }}
+            sx={{ width: "100px" }}
+          />
           <TextField
             variant="outlined"
             label="Comments"

--- a/src/app/assignments/speedgrader/page.jsx
+++ b/src/app/assignments/speedgrader/page.jsx
@@ -13,6 +13,16 @@ import { Prism as SyntaxHighlighter} from "react-syntax-highlighter";
 import { oneLight } from "react-syntax-highlighter/dist/esm/styles/prism";
 import MultipleSelect from "../../ui/studentSelector";
 
+const GradescopeCourseID = {
+  "Fa23": 576143,
+  "Sp24": 695053,
+};
+
+const GradescopeProject2ID = {
+  "Fa23": 3089460,
+  "Sp24": 3866728
+}
+
 const nameID = {
   "Oliver Hansen": 204884010,
   "Van Henry": 206666694,

--- a/src/app/ui/studentSelector.jsx
+++ b/src/app/ui/studentSelector.jsx
@@ -7,26 +7,14 @@ import MenuItem from "@mui/material/MenuItem";
 import FormControl from "@mui/material/FormControl";
 import Select from "@mui/material/Select";
 
-const names = ["Oliver Hansen", "Van Henry", "April Tucker", "Ralph Hubbard"];
-
-function getStyles(name, personName, theme) {
-  return {
-    fontWeight:
-      personName.indexOf(name) === -1
-        ? theme.typography.fontWeightRegular
-        : theme.typography.fontWeightMedium,
-  };
-}
-
 export default function MultipleSelect(props) {
   const theme = useTheme();
 
   const handleChange = async (event) => {
-    name = event.target.value;
-    props.setPersonName(name);
-    props.setPersonID(props.nameID[props.personName]);
+    const studentID = event.target.value;
+    props.setStudentID(studentID);
     const uri =
-      "http://localhost:4000/submissions?student_id=" + props.nameID[name];
+      "http://localhost:4000/submissions?student_id=" + studentID;
     const response = await fetch(uri);
     const data = await response.json();
     const feedback = data[0]["feedback"];
@@ -44,21 +32,21 @@ export default function MultipleSelect(props) {
   return (
     <div>
       <FormControl sx={{ width: 250 }}>
-        <InputLabel id="demo-multiple-name-label">Name</InputLabel>
+        <InputLabel id="Gradescope-student-ID-label">Gradescope Student ID</InputLabel>
         <Select
-          labelId="demo-multiple-name-label"
-          id="demo-multiple-name"
+          labelId="Gradescope-student-ID-label"
+          id="Gradescope-student-ID-select"
           value={props.personName}
           onChange={handleChange}
-          input={<OutlinedInput label="Name" />}
+          input={<OutlinedInput label="Gradescope Student ID" />}
         >
-          {names.map((name) => (
+          {props.studentIDs["Fa23"].map((studentID) => (
             <MenuItem
-              key={name}
-              value={name}
-              style={getStyles(name, props.personName, theme)}
+              key={studentID}
+              value={studentID}
+              // style={getStyles(name, props.personName, theme)}
             >
-              {name}
+              {studentID}
             </MenuItem>
           ))}
         </Select>


### PR DESCRIPTION
 ## Summary

- Removed fake names from Speedgrader page and replaced usages of fake names with the Gradescope student ID.
  - Also removed the getStyles function because it was based on the name and did not appear to impact anything.
- Added in ID maps for Fall 2023/Spring 2024 Gradescope courses and Project 2 assignments.
- Implemented a "Gradescope Submission" button that appears once a Gradescope student ID is selected and links to the student's submission using a new browser tab.
  - Google Chrome-specific issue where error page is reached but reloading page allows you to see submission. Error page does take quite a few seconds to reach and slows down workflow a lot, so would recommend any other browser is used for experiment unless Gradescope fixes this before.
- Speedgrader page buttons/tabs that require a Gradescope student ID to be selected to be useful are now hidden until an ID is selected.

## Feature Video

https://github.com/The-DSA-Duckies/aegon/assets/64329665/a3184475-9c2c-4592-9796-bae76ab96213

## Next Steps

- We'll have to replace the sample IDs with the actual subset of IDs from Spring 2024 for grading. We'll also have to replace the "Fa23" key usage with the "Sp24" key.
- I also am going to contact Gradescope via help@gradescope.com to let them know of the Google Chrome specific problem with having to reload the page to see the student submission.
- We will want to make it not as hard-coded for Project 2, but that will happen when the entire Speedgrader page is updated to handle different assignments.